### PR TITLE
Enable ESLint no-unused-vars rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,7 +20,7 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
-      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": "warn",
     },
   },
 );


### PR DESCRIPTION
Changed @typescript-eslint/no-unused-vars from "off" to "warn" to detect unused variables in the codebase. This helps maintain code quality without breaking the build.

- ESLint now detects 14 unused variable warnings
- Build still works correctly
- No dependency changes made